### PR TITLE
Remove non-breaking spaces from VAT ID

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -677,7 +677,7 @@ class VatCalculator
      */
     public function getVATDetails($vatNumber)
     {
-        $vatNumber = str_replace([' ', '-', '.', ','], '', trim($vatNumber));
+        $vatNumber = str_replace([' ', "\xC2\xA0", "\xA0", '-', '.', ','], '', trim($vatNumber));
         $countryCode = substr($vatNumber, 0, 2);
         $vatNumber = substr($vatNumber, 2);
         $this->initSoapClient();


### PR DESCRIPTION
These sometimes make it in while copy/pasting from various resources. Removes both Unicode and ISO-8859-x representation.

Originally https://github.com/mpociot/vat-calculator/pull/73