### PR TITLE
Add temp German VAT rate and a date when it gets back to regular rate

### DIFF
--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\VatCalculator;
 
 use PHPUnit_Framework_TestCase;
+use ReflectionClass;
 use SoapClient;
 use SoapFault;
 use Spaze\VatCalculator\Exceptions\VatCheckUnavailableException;
@@ -18,11 +19,20 @@ class VatCalculatorTest extends PHPUnit_Framework_TestCase
 	/** @var SoapClient */
 	private $vatCheck;
 
+	/** @var VatRates */
+	private $vatRates;
+
 
 	protected function setUp()
 	{
-		$this->vatCalculator = new VatCalculator(new VatRates());
+		$this->vatRates = new VatRates();
+		$this->vatCalculator = new VatCalculator($this->vatRates);
 		$this->vatCheck = $this->getMockFromWsdl(__DIR__ . '/checkVatService.wsdl', 'VatService');
+
+		$class = new ReflectionClass($this->vatRates);
+		$property = $class->getProperty('now');
+		$property->setAccessible(true);
+		$property->setValue($this->vatRates, strtotime('2020-06-30 23:59:59 Europe/Berlin'));
 	}
 
 

--- a/tests/VatRatesTest.php
+++ b/tests/VatRatesTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\VatCalculator;
 
 use PHPUnit_Framework_TestCase;
+use ReflectionClass;
 
 class VatRatesTest extends PHPUnit_Framework_TestCase
 {
@@ -37,6 +38,23 @@ class VatRatesTest extends PHPUnit_Framework_TestCase
 		$this->vatRates->addRateForCountry($country);
 		$this->assertFalse($this->vatRates->shouldCollectVat($country));
 		$this->assertEquals(0, $this->vatRates->getTaxRateForLocation($country, null));
+	}
+
+
+	public function testGetRatesSince(): void
+	{
+		$class = new ReflectionClass($this->vatRates);
+		$property = $class->getProperty('now');
+		$property->setAccessible(true);
+
+		$property->setValue($this->vatRates, strtotime('2020-06-30 23:59:59 Europe/Berlin'));
+		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null));
+
+		$property->setValue($this->vatRates, strtotime('2020-07-01 00:00:00 Europe/Berlin'));
+		$this->assertEquals(0.16, $this->vatRates->getTaxRateForLocation('DE', null));
+
+		$property->setValue($this->vatRates, strtotime('2021-01-01 00:00:00 Europe/Berlin'));
+		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null));
 	}
 
 }


### PR DESCRIPTION
Adds temporary DE VAT 16%

Also start of the support of historical (and future) rates, see the orig issue https://github.com/mpociot/vat-calculator/issues/91

Closes #3