### PR TITLE
Date-based VAT rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ $price->getTaxRate();
 To calculate the gross price (price with VAT added) use the `calculate` method with a net price, a country code, a postal code (null if unknow) and whether you're calculating VAT for a customer that's a company as paremeters.
 
 ```php
-$grossPrice = $vatCalculator->calculate(24.00, 'DE', null, false);
+$grossPrice = $vatCalculator->calculate(24.00, 'DE', null, false /* [, $rateType [, $dateTime]] */);
 ```
 The third parameter is the postal code of the customer, pass `null` if unknown.
 
 As a fourth parameter, you can pass in a boolean indicating whether the customer is a company or a private person. If the customer is a company, which you should check by <a href="#validate-eu-vat-numbers">validating the VAT number</a>, the net price gets returned.
 
-Fifth parameter defines which VAT rate to use if there are more defined for the particular country (`VatRates::HIGH`, `VatRates::LOW`, `VatRates::GENERAL` is the default when just one rate is defined).
+Fifth optional parameter defines which VAT rate to use if there are more defined for the particular country (`VatRates::HIGH`, `VatRates::LOW`, `VatRates::GENERAL` is the default when just one rate is defined).
+
+The sixth parameter, optional, specifies the date to use the VAT rate for. This is needed when a country changes its VAT rate and you want to calculate a price with the previous rate. Pass `DateTime` or `DateTimeImmutable` object. Current date used when not specified.
 
 Returns `VatPrice` object:
 ```php

--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\VatCalculator;
 
+use DateTimeImmutable;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 use SoapClient;
@@ -12,6 +13,8 @@ use stdClass;
 
 class VatCalculatorTest extends PHPUnit_Framework_TestCase
 {
+
+	private const DATE = '2020-06-30 23:59:59 Europe/Berlin';
 
 	/** @var VatCalculator */
 	private $vatCalculator;
@@ -32,7 +35,7 @@ class VatCalculatorTest extends PHPUnit_Framework_TestCase
 		$class = new ReflectionClass($this->vatRates);
 		$property = $class->getProperty('now');
 		$property->setAccessible(true);
-		$property->setValue($this->vatRates, strtotime('2020-06-30 23:59:59 Europe/Berlin'));
+		$property->setValue($this->vatRates, new DateTimeImmutable(self::DATE));
 	}
 
 
@@ -52,6 +55,9 @@ class VatCalculatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals(24.00, $result->getPrice());
 		$this->assertEquals(0.00, $result->getTaxRate());
 		$this->assertEquals(0.00, $result->getTaxValue());
+
+		$result = $this->vatCalculator->calculate(24.00, 'DE', null, false, VatRates::GENERAL, new DateTimeImmutable(self::DATE));
+		$this->assertEquals(28.56, $result->getPrice());
 	}
 
 
@@ -62,6 +68,9 @@ class VatCalculatorTest extends PHPUnit_Framework_TestCase
 
 		$result = $this->vatCalculator->getTaxRateForLocation('DE', null, true);
 		$this->assertEquals(0, $result);
+
+		$result = $this->vatCalculator->getTaxRateForLocation('DE', null, false, VatRates::GENERAL, new DateTimeImmutable(self::DATE));
+		$this->assertEquals(0.19, $result);
 	}
 
 

--- a/tests/VatRatesTest.php
+++ b/tests/VatRatesTest.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\VatCalculator;
 
+use DateTimeImmutable;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 
@@ -47,14 +48,20 @@ class VatRatesTest extends PHPUnit_Framework_TestCase
 		$property = $class->getProperty('now');
 		$property->setAccessible(true);
 
-		$property->setValue($this->vatRates, strtotime('2020-06-30 23:59:59 Europe/Berlin'));
+		$date = '2020-06-30 23:59:59 Europe/Berlin';
+		$property->setValue($this->vatRates, new DateTimeImmutable($date));
 		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null));
+		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null, VatRates::GENERAL, new DateTimeImmutable($date)));
 
-		$property->setValue($this->vatRates, strtotime('2020-07-01 00:00:00 Europe/Berlin'));
+		$date = '2020-07-01 00:00:00 Europe/Berlin';
+		$property->setValue($this->vatRates, new DateTimeImmutable($date));
 		$this->assertEquals(0.16, $this->vatRates->getTaxRateForLocation('DE', null));
+		$this->assertEquals(0.16, $this->vatRates->getTaxRateForLocation('DE', null, VatRates::GENERAL, new DateTimeImmutable($date)));
 
-		$property->setValue($this->vatRates, strtotime('2021-01-01 00:00:00 Europe/Berlin'));
+		$date = '2021-01-01 00:00:00 Europe/Berlin';
+		$property->setValue($this->vatRates, new DateTimeImmutable($date));
 		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null));
+		$this->assertEquals(0.19, $this->vatRates->getTaxRateForLocation('DE', null, VatRates::GENERAL, new DateTimeImmutable($date)));
 	}
 
 }


### PR DESCRIPTION
Specify an optional date to use the VAT rate for when calculating the price

Allows to issue invoices when a country has changed its VAT rate (like DE recently) and you want to issue an invoice for the period when the previous rate was still used.

This is a followup to #4 also mentioned https://github.com/mpociot/vat-calculator/issues/94.