### PR TITLE
Turkey Non-EU VAT rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ try {
 <a name="countries"></a>
 ## Countries
 
-EU countries are supported as well as some non-EU countries that use VAT. Some countries are not supported even though they also have VAT. Currently, that's the case for Norway which can be added manually with `VatRates::addRateForCountry()`.
+EU countries are supported as well as some non-EU countries that use VAT. Some countries are not supported even though they also have VAT. Currently, that's the case for the following countries:
+- Norway (NO)
+- Turkey (TR)
+These can be added manually with `VatRates::addRateForCountry()`:
 
 ```php
 $vatRates = new VatRates();
@@ -149,7 +152,7 @@ $vatRates->addRateForCountry('NO');
 $vatCalculator = new VatCalculator($vatRates);
 ```
 
-Please keep in mind that with countries like Norway you cannot validate VAT ids with `isValidVatNumber()` because it uses VIES, the EU VAT number validation service, and as Norway is not in the EU, it will always come back as invalid.
+Please keep in mind that with these countries you cannot validate VAT ids with `isValidVatNumber()` because it uses VIES, the EU VAT number validation service, and as these countries are not part of the EU, it will always come back as invalid.
 
 <a name="license"></a>
 ## License

--- a/src/VatRates.php
+++ b/src/VatRates.php
@@ -206,6 +206,9 @@ class VatRates
 		'NO' => [ // Norway
 			'rate' => 0.25,
 		],
+		'TR' => [ // Turkey
+			'rate' => 0.18,
+		],
 	];
 
 	/**


### PR DESCRIPTION
needs to be manually added by calling `addRateForCountry('TR')`, like Norway

Fix #8