### PR TITLE
Non-EU countries, no VAT

### DIFF
--- a/src/VatRates.php
+++ b/src/VatRates.php
@@ -181,15 +181,6 @@ class VatRates
 		'IM' => [ // Isle of Man - United Kingdom
 			'rate' => 0.20,
 		],
-
-		// Non-EU with their own VAT requirements
-		'CH' => [ // Switzerland
-			'rate' => 0.077,
-			'rates' => [
-				self::HIGH => 0.077,
-				self::LOW => 0.025,
-			],
-		],
 	];
 
 	/**
@@ -201,6 +192,13 @@ class VatRates
 	 * @var array<string, array>
 	 */
 	private $optionalTaxRules = [
+		'CH' => [ // Switzerland
+			'rate' => 0.077,
+			'rates' => [
+				self::HIGH => 0.077,
+				self::LOW => 0.025,
+			],
+		],
 		'NO' => [ // Norway
 			'rate' => 0.25,
 		],

--- a/src/VatRates.php
+++ b/src/VatRates.php
@@ -190,15 +190,13 @@ class VatRates
 				self::LOW => 0.025,
 			],
 		],
-		'TR' => [ // Turkey
-			'rate' => 0.18,
-		],
 	];
 
 	/**
 	 * Optional tax rules.
 	 *
-	 * These are added manually by `addRateForCountry()`
+	 * Non-EU countries with their own VAT requirements, countries in this list
+	 * need to be added manually by `addRateForCountry()` for the rate to be applied.
 	 *
 	 * @var array<string, array>
 	 */


### PR DESCRIPTION
Non-EU countries shouldn't be charged VAT automatically. This follows the Norway case.

Fix #8 (again)