### PR TITLE
Throw on invalid/non-EU country

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The given VAT numbers will be truncated and non relevant characters / whitespace
 
 This service relies on a third party SOAP API provided by the EU. If, for whatever reason, this API is unavailable a `VatCheckUnavailableException` will be thrown.
 
+If a VAT number from a unsupported/non-EU country is provided, `UnsupportedCountryException` will be thrown.
+
 ```php
 try {
 	$validVat = $vatCalculator->isValidVatNumber('NL 123456789 B01');
@@ -119,6 +121,8 @@ The VAT number should be in a format specified by the [VIES](http://ec.europa.eu
 The given VAT numbers will be truncated and non relevant characters / whitespace will automatically be removed.
 
 This service relies on a third party SOAP API provided by the EU. If, for whatever reason, this API is unavailable a `VatCheckUnavailableException` will be thrown.
+
+If a VAT number from a unsupported/non-EU country is provided, `UnsupportedCountryException` will be thrown.
 
 ```php
 try {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,7 @@
 * `getIPBasedCountry()` & `getClientIP()` methods have been removed, use some other package (or `CF-IPCountry` HTTP header if you're behind Cloudflare)
 * Some methods have been properly *camelCased*: methods like `getClientIP()` -> `getClientIp()` and `shouldCollectVAT` -> `shouldCollectVat` and a few more
 * `VATCheckUnavailableException` has been *camelCased* to `VatCheckUnavailableException`
+* If a VAT number from a unsupported/non-EU country is provided for validation or for `getVatDetails()` call, `UnsupportedCountryException` will be thrown
 * Requires PHP 7.3
 
 # Upgrading from 1.* to 2.*

--- a/src/Exceptions/UnsupportedCountryException.php
+++ b/src/Exceptions/UnsupportedCountryException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\VatCalculator\Exceptions;
+
+use Exception;
+use Throwable;
+
+class UnsupportedCountryException extends Exception
+{
+
+	public function __construct(string $countryCode, int $code = 0, Throwable $previous = null)
+	{
+		parent::__construct('Unsupported/non-EU country ' . $countryCode, $code, $previous);
+	}
+
+}

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\VatCalculator;
 
 use DateTimeInterface;
+use Spaze\VatCalculator\Exceptions\UnsupportedCountryException;
 use Spaze\VatCalculator\Exceptions\VatCheckUnavailableException;
 use SoapClient;
 use SoapFault;
@@ -139,6 +140,11 @@ class VatCalculator
 		$vatNumber = str_replace([' ', "\xC2\xA0", "\xA0", '-', '.', ','], '', trim($vatNumber));
 		$countryCode = substr($vatNumber, 0, 2);
 		$vatNumber = substr($vatNumber, 2);
+
+		if (!$this->shouldCollectVat($countryCode)) {
+			throw new UnsupportedCountryException($countryCode);
+		}
+
 		try {
 			if ($this->soapClient === null) {
 				$this->soapClient = new SoapClient(self::VAT_SERVICE_URL);


### PR DESCRIPTION
Don't even send non-EU countries to VIES, it would always throw SoapFault, throw `UnsupportedCountryException` instead.

Fix #13