### PR TITLE
Trigger a notice because some folks are still using the package, Packagist says

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -37,6 +37,7 @@ class VatCalculator
 
 	public function __construct(VatRates $vatRates, ?string $businessCountryCode = null, ?string $businessVatNumber = null, ?float $timeout = null)
 	{
+		trigger_error('Hi, please stop using spaze/vat-calculator, it is not supported anymore, the VAT rates may be incorrect. Use https://github.com/driesvints/vat-calculator and for more info see https://github.com/spaze/vat-calculator/releases/tag/v3.6.6', E_USER_NOTICE);
 		$this->vatRates = $vatRates;
 		if ($businessCountryCode) {
 			$this->setBusinessCountryCode($businessCountryCode);


### PR DESCRIPTION
See https://github.com/spaze/vat-calculator/releases/tag/v4.0.4 and the release mentioned in the notice will be created and in the 3.6.x series because some people may have something like `^3.6` in their `composer.json`.